### PR TITLE
Payment notification fixes

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -92,7 +92,7 @@ class AdyenNotification < ActiveRecord::Base
     # If no reference take the last payment in the associated order where the
     # response_code was nil.
     if order
-      order
+      payment_with_reference = order
         .payments
         .joins(:payment_method)
         .where(
@@ -102,6 +102,8 @@ class AdyenNotification < ActiveRecord::Base
           response_code: nil
         )
         .last
+      payment_with_reference.update_attribute :response_code, reference
+      payment_with_reference
     end
   end
 

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -101,6 +101,7 @@ class AdyenNotification < ActiveRecord::Base
           },
           response_code: nil
         )
+        .where(payment_state_option)
         .last
       payment_with_reference.update_attribute :response_code, reference
       payment_with_reference
@@ -183,4 +184,13 @@ class AdyenNotification < ActiveRecord::Base
   end
 
   alias_method :authorization?, :authorisation?
+
+  private
+
+  def payment_state_option
+    # select payment with matching state
+    if authorisation?
+      { state: [:pending, :processing] }
+    end
+  end
 end

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -51,11 +51,8 @@ module Spree
 
       def handle_failure
         notification.processed!
-        # ignore failures if the payment was already completed, or if it doesn't
-        # exist
-        return if payment.nil? || payment.completed? || payment.failed?
-        # might have to do something else on modification events,
-        # namely refunds
+        # might have to do something else on modification events, namely refunds
+        # let it fail if something is wrong
         payment.failure!
       end
 

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -82,13 +82,6 @@ module Spree
 
       # normal event is defined as just AUTHORISATION
       def handle_normal_event
-        # Payment may not have psp_reference. Add this from notification if it
-        # doesn't have one.
-        unless self.payment.response_code
-          payment.response_code = notification.psp_reference
-          payment.save
-        end
-
         if notification.auto_captured?
           complete_payment!
 


### PR DESCRIPTION
This pull requests resolves the following issues:

1. failure notifications did not update payment with their psp_reference
2. sometimes a failure event arrived after a new 'checkout' payment and was creating an error when the notification attempted to mark the new payment as failed

Pivotal #173032752