### PR TITLE
174294761 | Set guest_token cookie for guest orders

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -30,6 +30,14 @@ module Spree
       payment_method = payment.payment_method
       @order = payment.order
 
+      # If this is a guest order, the user is nil
+      # And something is blowing away this cookie during the redirects
+      # So we need to restore the token in the cookie so the redirect
+      # to the order works
+      unless @order.user
+        cookies.permanent.signed[:guest_token] = @order.guest_token
+      end
+
       payment_method.authorize_3d_secure_payment(payment, adyen_3d_params)
       payment.capture! if payment_method.auto_capture
 


### PR DESCRIPTION
Pivotal 174294761 -> https://www.pivotaltracker.com/story/show/174294761 

Something is blowing away this cookie through all of the redirects that are happening and a new one gets assigned.

So by restoring this cookie for guest orders we can ensure that the user is not redirected to the login page for their cookie guest token not matching the one on the order.

Since we're getting the order from the MD5 hash that came back from the redirect, I think we can be fairly sure that they should have the guest_token from that order.