### PR TITLE
Revert previous 2 commits that were not working

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -101,7 +101,7 @@ class AdyenNotification < ActiveRecord::Base
           },
           response_code: nil
         )
-        .where.not(state: "completed")
+        .where(payment_state_option)
         .last
       payment_with_reference.update_attribute :response_code, reference
       payment_with_reference
@@ -185,4 +185,12 @@ class AdyenNotification < ActiveRecord::Base
 
   alias_method :authorization?, :authorisation?
 
+  private
+
+  def payment_state_option
+    # select payment with matching state
+    if authorisation?
+      { state: [:pending, :processing] }
+    end
+  end
 end

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -101,7 +101,7 @@ class AdyenNotification < ActiveRecord::Base
           },
           response_code: nil
         )
-        .where.not(payment_state_option)
+        .where.not(state: "completed")
         .last
       payment_with_reference.update_attribute :response_code, reference
       payment_with_reference
@@ -185,12 +185,4 @@ class AdyenNotification < ActiveRecord::Base
 
   alias_method :authorization?, :authorisation?
 
-  private
-
-  def payment_state_option
-    # select payment with matching state
-    if authorisation?
-      { state: "completed" }
-    end
-  end
 end


### PR DESCRIPTION
This reverts the commits done in PR #3 and #4 as they were causing problems and are no longer being used by watg-solidus as it is using the specific commit of when PR #2 was merged.