### PR TITLE
Resolve order update deadlock

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -103,7 +103,7 @@ class AdyenNotification < ActiveRecord::Base
         )
         .where(payment_state_option)
         .last
-      payment_with_reference.update_attribute :response_code, reference
+      payment_with_reference.update_column :response_code, reference
       payment_with_reference
     end
   end


### PR DESCRIPTION
A deadlock was sometimes occurring with two separate update events on
the order table. It appears that this was occurring because the
change to add the response_code code via update_attributes
resulted in the order updated_at time to be updated when it was
locked by another transaction. Updating the payment update_column
should hopefully resolve this conflict. Because it only clashed on
about 1% of orders - probably when the server was busy, it is not
easy to test. However, this appears to be a harmless change that is
worth testing on live whether this change is enough to avoid the
deadlock.
https://sentry.io/share/issue/999ff22e4ab94e63b998784f6d520c31/
Pivotal: [#175442519](https://www.pivotaltracker.com/story/show/175442519)