### PR TITLE
Deprecate call to `provider_class`

### DIFF
--- a/app/models/concerns/spree/payment_method/adyen_payment_method.rb
+++ b/app/models/concerns/spree/payment_method/adyen_payment_method.rb
@@ -28,7 +28,7 @@ module Spree
       )
     end
 
-    def provider_class
+    def gateway_class
       ::Adyen::REST
     end
 

--- a/spec/models/spree/payment_method/adyen_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/adyen_credit_card_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Spree::PaymentMethod::AdyenCreditCard do
   it { is_expected.to be_a(Spree::PaymentMethod) }
 
-  describe 'provider_class' do
-    subject { described_class.new.provider_class }
+  describe 'gateway_class' do
+    subject { described_class.new.gateway_class }
 
     it { is_expected.to eq(Adyen::REST) }
   end


### PR DESCRIPTION
This fixes the following deprecation warning:

.DEPRECATION WARNING: provider_class is deprecated and will be removed
from Solidus 3.0 (use gateway_class instead)
