### PR TITLE
Add an optional capture amount to capture!

### DIFF
--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -31,7 +31,7 @@ module Spree
       end
 
       # capture! :: bool | error
-      def capture!
+      def capture!(capture_amount = nil)
         if hpp_payment? || adyen_cc_payment? || ratepay?
           amount = money.money.cents
           process do

--- a/spec/models/concerns/spree/adyen/payment_spec.rb
+++ b/spec/models/concerns/spree/adyen/payment_spec.rb
@@ -225,8 +225,10 @@ describe Spree::Adyen::Payment do
   end
 
   describe "capture!" do
-    subject { payment.capture! }
+    subject { payment.capture!(*args) }
     include_examples "gateway action", Spree::PaymentMethod::AdyenHPP
+
+    let(:args) { [] }
 
     context "when the payment doesn't have an hpp source" do
       let(:payment) { create :payment }
@@ -239,6 +241,17 @@ describe Spree::Adyen::Payment do
 
           and change { payment.capture_events.count }.
           by(1)
+      end
+
+      context "when a capture amount is passed in" do
+        let(:args) { [123] }
+
+        it "keeps the original behaviour and doesn't error" do
+          expect{ subject }
+            .to change { payment.reload.state }
+            .from("checkout")
+            .to("completed")
+        end
       end
     end
   end


### PR DESCRIPTION
Other implementations of the capture! method have this optional argument. This means that if this is the super method of a capture! method that has the argument then it will error due to wrong number of arguments.