### PR TITLE
Rename deprecated `method_type` to `partial_name`

### DIFF
--- a/app/models/spree/payment_method/adyen_credit_card.rb
+++ b/app/models/spree/payment_method/adyen_credit_card.rb
@@ -19,7 +19,7 @@ module Spree
       ENV["ADYEN_CSE_LIBRARY_LOCATION"] || preferred_cse_library_location
     end
 
-    def method_type
+    def partial_name
       "adyen_encrypted_cc"
     end
 

--- a/app/models/spree/payment_method/adyen_hpp.rb
+++ b/app/models/spree/payment_method/adyen_hpp.rb
@@ -8,7 +8,7 @@ module Spree
     preference :days_to_ship, :integer, default: 1
     preference :restricted_brand_codes, :string, default: ''
 
-    def method_type
+    def partial_name
       "adyen"
     end
 

--- a/app/models/spree/payment_method/adyen_ratepay.rb
+++ b/app/models/spree/payment_method/adyen_ratepay.rb
@@ -16,7 +16,7 @@ module Spree
       ENV["RATEPAY_DEVICE_SID"] || preferred_device_sid
     end
 
-    def method_type
+    def partial_name
       "adyen_ratepay"
     end
 

--- a/spec/models/spree/payment_method/adyen_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/adyen_credit_card_spec.rb
@@ -9,8 +9,8 @@ describe Spree::PaymentMethod::AdyenCreditCard do
     it { is_expected.to eq(Adyen::REST) }
   end
 
-  describe 'method_type' do
-    subject { described_class.new.method_type }
+  describe 'partial_name' do
+    subject { described_class.new.partial_name }
 
     it { is_expected.to eq("adyen_encrypted_cc") }
   end

--- a/spec/models/spree/payment_method/adyen_ratepay_spec.rb
+++ b/spec/models/spree/payment_method/adyen_ratepay_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::PaymentMethod::AdyenRatepay do
   let(:ratepay) { build_stubbed :ratepay_gateway }
 
-  describe "#method_type" do
+  describe "#partial_name" do
     it "is always 'adyen_ratepay'" do
-      expect(ratepay.method_type).to eq "adyen_ratepay"
+      expect(ratepay.partial_name).to eq "adyen_ratepay"
     end
   end
 


### PR DESCRIPTION
Deprecation warning:

`method_type` is deprecated and will be removed from Solidus 3.0 (use
partial_name instead)

https://github.com/solidusio/solidus/commit/8142809ef69e4e8b7902c14316bfcbf04265c574


PS: I love that I am still adding updates to this integration!!!! It's the best!!!!