### PR TITLE
Fix refunds aka "credit" bug

### DIFF
--- a/app/models/concerns/spree/payment_method/adyen_payment_method.rb
+++ b/app/models/concerns/spree/payment_method/adyen_payment_method.rb
@@ -49,9 +49,9 @@ module Spree
 
     def credit(amount, source = nil, psp_reference, gateway_options)
       # in the case of a "refund", we don't have the full gateway_options
-      currency ||= gateway_options[:originator].payment.currency
+      currency ||= gateway_options[:originator].currency
       params = modification_request(amount, currency, psp_reference)
-      params.merge!(options.slice(:additional_data)) if gateway_options[:additional_data]
+      params.merge!(gateway_options.slice(:additional_data)) if gateway_options[:additional_data]
 
       handle_response(rest_client.refund_payment(params), psp_reference)
     end


### PR DESCRIPTION
Refunds were reported as non-functional on Sirdar today with the
following error:

NoMethodError
undefined method `payment' for #<Spree::Payment id: 248826...

Not really sure how this bug was introduced as we basically just renamed
the variable from options to gateway_options in our previous change to
support Ruby 3.0 via argument restructuring.

The diff looked like this:

-- currency ||= options[:originator].payment.currency
++ currency ||= gateway_options[:originator].payment.currency

Anyway it works again if you don't try to fetch the payment off the
payment, so that is the change I make here.

I also fix what is a real acutal bug where we would never have merged
the `:additional_data` from the gateway_options due to missing a step in
the rename.
