### PR TITLE
Revert AdyenPaymentMethod#cancel! method signature

### DIFF
--- a/app/models/concerns/spree/payment_method/adyen_payment_method.rb
+++ b/app/models/concerns/spree/payment_method/adyen_payment_method.rb
@@ -38,7 +38,7 @@ module Spree
       handle_response(rest_client.capture_payment(params), psp_reference)
     end
 
-    def cancel(psp_reference, _gateway_options)
+    def cancel(psp_reference, _gateway_options = {})
       params = {
         merchant_account: account_locator.by_reference(psp_reference),
         original_reference: psp_reference


### PR DESCRIPTION
The method signature was originally changed in #15 that made the extension compatible with Ruby 3.x.

The previous version is compatible with Ruby 3.x, while the new one was not equivalent to the old one as it requires the second param, which is irrelevant in the context of the method, to be present.

The new signature poses an issues at least on Rowan, as it prevents payments to be cancelled. This is from Rowan staging:

    Spree::Order.find_by(number: 'KR700391505').payments.first.cancel!
    D, [2024-06-13T08:17:47.239828 #2] DEBUG -- :   TRANSACTION (1.1ms)  ROLLBACK
    /app/vendor/bundle/ruby/3.0.0/bundler/gems/solidus-adyen-f654fd0d419c/app/models/concerns/spree/payment_method/adyen_payment_method.rb:41:in `cancel': wrong number of arguments (given 1, expected 2) (ArgumentError)