### PR TITLE
Add CSE library integrity preference

### DIFF
--- a/app/models/spree/payment_method/adyen_credit_card.rb
+++ b/app/models/spree/payment_method/adyen_credit_card.rb
@@ -14,9 +14,14 @@ module Spree
 
     include Spree::PaymentMethod::AdyenPaymentMethod
     preference :cse_library_location, :string
+    preference :cse_library_location_integrity, :string
 
     def cse_library_location
       ENV["ADYEN_CSE_LIBRARY_LOCATION"] || preferred_cse_library_location
+    end
+
+    def cse_library_location_integrity
+      preferred_cse_library_location_integrity
     end
 
     def partial_name

--- a/app/models/spree/payment_method/adyen_credit_card.rb
+++ b/app/models/spree/payment_method/adyen_credit_card.rb
@@ -24,6 +24,13 @@ module Spree
       preferred_cse_library_location_integrity
     end
 
+    def checkoutshopper_cse_library_location
+      return unless cse_library_location.present?
+
+      code = cse_library_location.split("/").last.split(".").first
+      "https://checkoutshopper-#{preferred_server}.adyen.com/checkoutshopper/utility/v1/cse/js/#{code}.shtml"
+    end
+
     def partial_name
       "adyen_encrypted_cc"
     end

--- a/spec/models/spree/payment_method/adyen_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/adyen_credit_card_spec.rb
@@ -46,6 +46,20 @@ describe Spree::PaymentMethod::AdyenCreditCard do
     end
   end
 
+  describe 'cse_library_location_integrity' do
+    subject { described_class.new.cse_library_location_integrity }
+
+    it { is_expected.to be_nil }
+
+    context "with a preference set" do
+      subject do
+        described_class.new(preferred_cse_library_location_integrity: "SOMETHING").cse_library_location_integrity
+      end
+
+      it { is_expected.to eq("SOMETHING") }
+    end
+  end
+
   describe 'api_username' do
     subject { described_class.new.api_username }
 

--- a/spec/models/spree/payment_method/adyen_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/adyen_credit_card_spec.rb
@@ -60,6 +60,34 @@ describe Spree::PaymentMethod::AdyenCreditCard do
     end
   end
 
+  describe '#checkoutshopper_cse_library_location' do
+    let(:payment_method) { described_class.new }
+
+    subject { payment_method.checkoutshopper_cse_library_location }
+
+    context 'when cse_library_location is blank' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when cse_library_location is present' do
+      before do
+        payment_method.preferred_cse_library_location = 'https://live.adyen.com/hpp/cse/js/12345.shtml'
+      end
+
+      context 'when server is live' do
+        before { payment_method.preferred_server = 'live' }
+
+        it { is_expected.to eq('https://checkoutshopper-live.adyen.com/checkoutshopper/utility/v1/cse/js/12345.shtml') }
+      end
+
+      context 'when server is test' do
+        before { payment_method.preferred_server = 'test' }
+
+        it { is_expected.to eq('https://checkoutshopper-test.adyen.com/checkoutshopper/utility/v1/cse/js/12345.shtml') }
+      end
+    end
+  end
+
   describe 'api_username' do
     subject { described_class.new.api_username }
 


### PR DESCRIPTION
The integrity SHA is going to be required soon for CSE integrations.

For each legacy credit card payment method we need to include this new information in the payment method preferences. This is going to be used when generating the script tag on the FE for loading the appropriate CSE library, and allows to verify the integrity of the script. The integrity code is available in the Adyen admin area for
each payment method.

Also, we need to use a new URL, as the old one provided by Adyen is not CORS compatible with the new integrity attribute. 

The new preference can be added/edited in the admin page for the payment method.

<img width="579" alt="Screenshot 2025-03-10 at 09 32 47" src="https://github.com/user-attachments/assets/f6ed560e-74d7-4f13-96b5-d0822ff6cd96" />
